### PR TITLE
fix for URLs with minus sign in it

### DIFF
--- a/Controller/Payment/Redirect.php
+++ b/Controller/Payment/Redirect.php
@@ -135,7 +135,7 @@ class Redirect extends \Payrexx\PaymentGateway\Controller\AbstractAction
 
         // Add current/default language into URL
         return preg_replace(
-            '/^(https:\/\/[a-z0-9.]+)\/(.*)$/',
+            '/^(https:\/\/[a-z0-9.\-]+)\/(.*)$/',
             '$1/'. $lang .'/$2',
             $url
         );


### PR DESCRIPTION
With the old pattern language parameter will not be added to URL when the payrexx subdomain contains a minus sign.