### PR TITLE
bugfix/PP-16400: Stock Adjustments When Payment Gets Cancelled (Magento2)

### DIFF
--- a/Controller/Payment/Redirect.php
+++ b/Controller/Payment/Redirect.php
@@ -2,10 +2,10 @@
 /**
  * Payrexx Payment Gateway Module
  *
- * @category  Payrexx
- * @package   Payrexx_PaymentGateway
- * @author    Support <support@payrexx.com>
- * @copyright PAYREXX AG
+ * @author      Payrexx <support@payrexx.com>
+ * @copyright   Payrexx AG
+ * @package     magento2
+ * @subpackage  payrexx_payment_gateway
  */
 namespace Payrexx\PaymentGateway\Controller\Payment;
 
@@ -68,6 +68,7 @@ class Redirect extends \Payrexx\PaymentGateway\Controller\AbstractAction
 
         $gateway->setSkipResultPage(true);
         $gateway->setPsp([]);
+        $gateway->setValidity(15);
         $gateway->setAmount($order->getGrandTotal() * 100);
         $gateway->setCurrency($order->getOrderCurrencyCode());
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "license": [
         "OSL-3.0"
     ],
-    "version": "1.3.19",
+    "version": "1.3.20",
     "autoload": {
         "files": [
             "registration.php"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -3,14 +3,14 @@
 /**
  * Payrexx Payment Gateway Module
  *
- * @category  Payrexx
- * @package   Payrexx_PaymentGateway
- * @author    Support <support@payrexx.com>
- * @copyright PAYREXX AG
+ * @author      Payrexx <support@payrexx.com>
+ * @copyright   Payrexx AG
+ * @package     magento2
+ * @subpackage  payrexx_payment_gateway
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Payrexx_PaymentGateway" setup_version="1.3.19">
+    <module name="Payrexx_PaymentGateway" setup_version="1.3.20">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
**Testcase 1:**

1. Checkout the product and redirect to the Payrexx payment gateway.
2. Filled failed card number and submitted
3. The webhook updates the status to canceled.
4. The product stock is not reduced.

**Testcase 2:**

1. Checkout the product and redirect to the Payrexx payment gateway.
2. Filled success card number and submitted
3. The webhook updates the status to canceled.
4. The product stock was reduced.