### PR TITLE
bugfix/PP-19812: Confirmed Payment on a Canceled Order Locks It in "closed"

### DIFF
--- a/Controller/AbstractAction.php
+++ b/Controller/AbstractAction.php
@@ -30,6 +30,21 @@ abstract class AbstractAction extends \Magento\Framework\App\Action\Action
     const PAYMENT_SECURITY_HASH = 'payrexx_security_hash';
 
     /**
+     * Uses additional_information as storage
+     */
+    const PAYMENT_TRANSACTION_ID = 'payrexx_transaction_id';
+
+    /**
+     * Uses additional_information as storage
+     */
+    const PAYMENT_TRANSACTION_UUID = 'payrexx_transaction_uuid';
+
+    /**
+     * Uses additional_information as storage
+     */
+    const PAYMENT_CANCELED_ORDER_NOTICE = 'payrexx_canceled_order_notice';
+
+    /**
      * @var \Magento\Framework\App\Action\Context
      */
     public $context;

--- a/Controller/Payment/Failure.php
+++ b/Controller/Payment/Failure.php
@@ -80,7 +80,10 @@ class Failure extends \Payrexx\PaymentGateway\Controller\AbstractAction
                 try {
                     $payrexx->delete($payrexxGateway);
                 } catch (\Payrexx\PayrexxException $e) {
-                    // no action.
+                    $this->logger->warning(
+                        'Payrexx Gateway deletion failed. Gateway ID: ' . $gatewayId
+                        . ' - ' . $e->getMessage()
+                    );
                 }
             }
         }

--- a/Controller/Payment/Webhook.php
+++ b/Controller/Payment/Webhook.php
@@ -122,6 +122,60 @@ class Webhook extends \Payrexx\PaymentGateway\Controller\AbstractAction
         if (!$this->isAllowedToChangeState($order->getState(), $state)) {
             return;
         }
+        // Forcing a canceled order to processing lets Magento close it, which is terminal.
+        if ($order->isCanceled()
+            && in_array($state, [Order::STATE_PROCESSING, Order::STATE_PENDING_PAYMENT], true)
+        ) {
+            $transactionId = isset($transaction['id']) ? (string) $transaction['id'] : '';
+            $noticeKey = $transactionId . '-' . $status;
+            $knownNoticeKey = (string) $payment->getAdditionalInformation(
+                static::PAYMENT_CANCELED_ORDER_NOTICE
+            );
+            if ($transactionId !== '' && $noticeKey === $knownNoticeKey) {
+                return;
+            }
+
+            $this->logger->warning(
+                'Payrexx Webhook: ' . $status . ' transaction received for the canceled order '
+                . $order->getIncrementId() . '. Gateway ID: ' . $gatewayId
+                . ', transaction ID: ' . $transactionId
+            );
+
+            if ($transactionId !== '') {
+                $payment->setAdditionalInformation(
+                    static::PAYMENT_TRANSACTION_ID,
+                    $transactionId
+                );
+                $payment->setAdditionalInformation(
+                    static::PAYMENT_CANCELED_ORDER_NOTICE,
+                    $noticeKey
+                );
+            }
+            if (!empty($transaction['uuid'])) {
+                $payment->setAdditionalInformation(
+                    static::PAYMENT_TRANSACTION_UUID,
+                    $transaction['uuid']
+                );
+            }
+            $payment->save();
+
+            if ($state === Order::STATE_PROCESSING) {
+                $comment = 'Payrexx: payment confirmed for an already canceled order. The order was '
+                    . 'left canceled - please refund the payment in Payrexx or create a new order '
+                    . 'manually.';
+            } else {
+                $comment = 'Payrexx: waiting payment update received for an already canceled order. '
+                    . 'The order was left canceled.';
+            }
+
+            if ($transactionId !== '') {
+                $comment .= ' Transaction ID: ' . $transactionId . '.';
+            }
+
+            $order->addCommentToStatusHistory($comment);
+            $order->save();
+            return;
+        }
         if ($state === Order::STATE_CANCELED && $order->canCancel()) {
             $order->registerCancellation('Order was canceled via Payrexx webhook')->save();
         } else {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "license": [
         "OSL-3.0"
     ],
-    "version": "1.4.9",
+    "version": "1.4.10",
     "autoload": {
         "files": [
             "registration.php"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -10,7 +10,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Payrexx_PaymentGateway" setup_version="1.4.9">
+    <module name="Payrexx_PaymentGateway" setup_version="1.4.10">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
**Problem**

When an order is canceled and a `confirmed` payment webhook arrives afterwards,
the order ends up locked in Magento's terminal `closed` state — no invoice, no
shipment, and it cannot even be credit-memo'd. The payment is captured at
Payrexx while the Magento document is unusable, so the merchant has to refund
manually and recreate the order.

The order can reach `canceled` in three ways: the customer aborts on the Payrexx
page, the customer re-enters the shop checkout (`RestoreCartObserver`), or
Magento's `CleanExpiredOrders` cron cleans up a stale `pending_payment` order.

The lock itself happens inside Magento core, not in this module: the webhook
forced the order to `processing`, and during `$order->save()`
`ResourceModel\Order\Handler\State::checkForClosedState()` flips it to
`STATE_CLOSED` — the order is processing, all items are canceled so it cannot be
shipped, `totalPaid` is 0 so it cannot be credit-memo'd, and it is not virtual.
A misleading order confirmation email was sent on top of that.

**Fix**

`Controller/Payment/Webhook.php` — a `confirmed` or `waiting` update on an
already-canceled order no longer changes the order state. Instead the module
logs a warning, stores the Payrexx transaction ID and UUID on the payment, and
adds a status-history comment telling the merchant to refund in Payrexx or
create a new order manually. The early return skips both the invoice creation
and the confirmation email.

The notice is keyed on transaction ID + status, so repeated deliveries of the
same webhook write nothing, while a `waiting` → `confirmed` progression still
produces the confirmation notice (relevant for invoice/bank transfer methods,
where the merchant otherwise would never learn that money actually arrived).

`Controller/Payment/Failure.php` — a swallowed `PayrexxException` during gateway
deletion is now logged. A failed deletion is one of the paths into this bug and
was previously invisible.